### PR TITLE
model provider system for multiplayer notes

### DIFF
--- a/SiraUtil/Objects/MultiplayerConnectedPlayerRedecorator.cs
+++ b/SiraUtil/Objects/MultiplayerConnectedPlayerRedecorator.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using Zenject;
+
+namespace SiraUtil.Objects
+{
+    [HarmonyPatch(typeof(MultiplayerConnectedPlayerInstaller), nameof(MultiplayerConnectedPlayerInstaller.InstallBindings))]
+    internal class MultiplayerConnectedPlayerRedecorator
+    {
+        private static MultiplayerConnectedPlayerGameNoteController _staticMultiplayerGameNotePrefab;
+        private static MultiplayerConnectedPlayerBombNoteController _staticMultiplayerBombNotePrefab;
+
+        internal static void Prefix(ref MultiplayerConnectedPlayerInstaller __instance, ref MultiplayerConnectedPlayerGameNoteController ____multiplayerGameNoteControllerPrefab,
+            ref MultiplayerConnectedPlayerBombNoteController ____multiplayerBombNoteControllerPrefab, ref IConnectedPlayer ____connectedPlayer)
+        {
+            var mib = __instance as MonoInstallerBase;
+            DiContainer Container = Accessors.GetDiContainer(ref mib);
+
+            Container.BindInstance(____connectedPlayer).WithId("sirautil.connectedplayer");
+            Container.QueueForInject(____connectedPlayer);
+
+            _staticMultiplayerGameNotePrefab = ____multiplayerGameNoteControllerPrefab;
+            _staticMultiplayerBombNotePrefab = ____multiplayerBombNoteControllerPrefab;
+
+            if (_staticMultiplayerGameNotePrefab != null)
+            {
+                ____multiplayerGameNoteControllerPrefab = _staticMultiplayerGameNotePrefab;
+            }
+            if (_staticMultiplayerBombNotePrefab != null)
+            {
+                ____multiplayerBombNoteControllerPrefab = _staticMultiplayerBombNotePrefab;
+            }
+
+            var normal = BeatmapObjectRedecorator.InstallModelProviderSystem(Container, ____multiplayerGameNoteControllerPrefab);
+            var bomb = BeatmapObjectRedecorator.InstallModelProviderSystem(Container, ____multiplayerBombNoteControllerPrefab);
+            if (normal != null)
+            {
+                ____multiplayerGameNoteControllerPrefab = normal;
+            }
+            if (bomb != null)
+            {
+                ____multiplayerBombNoteControllerPrefab = bomb;
+            }
+        }
+    }
+}

--- a/SiraUtil/Objects/MultiplayerConnectedPlayerRedecorator.cs
+++ b/SiraUtil/Objects/MultiplayerConnectedPlayerRedecorator.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using HarmonyLib;
 using Zenject;
+using HarmonyLib;
 
 namespace SiraUtil.Objects
 {
@@ -14,14 +9,12 @@ namespace SiraUtil.Objects
         private static MultiplayerConnectedPlayerGameNoteController _staticMultiplayerGameNotePrefab;
         private static MultiplayerConnectedPlayerBombNoteController _staticMultiplayerBombNotePrefab;
 
-        internal static void Prefix(ref MultiplayerConnectedPlayerInstaller __instance, ref MultiplayerConnectedPlayerGameNoteController ____multiplayerGameNoteControllerPrefab,
-            ref MultiplayerConnectedPlayerBombNoteController ____multiplayerBombNoteControllerPrefab, ref IConnectedPlayer ____connectedPlayer)
+        internal static void Prefix(ref MultiplayerConnectedPlayerInstaller __instance,
+            ref MultiplayerConnectedPlayerGameNoteController ____multiplayerGameNoteControllerPrefab,
+            ref MultiplayerConnectedPlayerBombNoteController ____multiplayerBombNoteControllerPrefab)
         {
             var mib = __instance as MonoInstallerBase;
             DiContainer Container = Accessors.GetDiContainer(ref mib);
-
-            Container.BindInstance(____connectedPlayer).WithId("sirautil.connectedplayer");
-            Container.QueueForInject(____connectedPlayer);
 
             _staticMultiplayerGameNotePrefab = ____multiplayerGameNoteControllerPrefab;
             _staticMultiplayerBombNotePrefab = ____multiplayerBombNoteControllerPrefab;

--- a/SiraUtil/SiraUtil.csproj
+++ b/SiraUtil/SiraUtil.csproj
@@ -56,6 +56,11 @@
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="BGNet, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNet.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="GameplayCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
@@ -203,6 +208,7 @@
     <Compile Include="Interfaces\IRegistrar.cs" />
     <Compile Include="Interfaces\IToggleable.cs" />
     <Compile Include="Objects\BeatmapObjectRedecorator.cs" />
+    <Compile Include="Objects\MultiplayerConnectedPlayerRedecorator.cs" />
     <Compile Include="Objects\ObjectState.cs" />
     <Compile Include="Objects\ObjectStateContainer.cs" />
     <Compile Include="Objects\SiraPrefabContainer.cs" />


### PR DESCRIPTION
I also added an [injection](https://github.com/Auros/SiraUtil/compare/master...AuriRex:multiplayer-note-decorator?expand=1#diff-35adcd0f9402f66747297bcdb68c628386125d2cb36ef6167bdd22ee80f89d00R24) for IConnectedPlayer that isn't injected by the base game into this container because it's useful for multiplayer custom notes. I'm not sure if that's the best way to handle injecting this but it works.