### PR TITLE
Hide pointer glow in replays when FPFCToggle is enabled

### DIFF
--- a/SiraUtil/Tools/FPFCToggle.cs
+++ b/SiraUtil/Tools/FPFCToggle.cs
@@ -66,6 +66,17 @@ namespace SiraUtil.Tools
                 _leftController.transform.localPosition = Vector3.zero;
                 _rightController.transform.localPosition = Vector3.zero;
                 _vrLaserPointer.gameObject.SetActive(newScene.name != "GameCore");
+                if (newScene.name == "GameCore")
+                {
+                    foreach (Parametric3SliceSpriteController fakeGlow in _leftController.transform.GetComponentsInChildren<Parametric3SliceSpriteController>())
+                    {
+                        fakeGlow.enabled = false;
+                    }
+                    foreach (Parametric3SliceSpriteController fakeGlow in _rightController.transform.GetComponentsInChildren<Parametric3SliceSpriteController>())
+                    {
+                        fakeGlow.enabled = false;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
With FPFCToggle enabled and bloom post-process disabled, the controller pointer's fake glow shows up in replays right in front of the camera and can be a bit distracting:
![image](https://user-images.githubusercontent.com/17561672/114260289-bd920f00-9988-11eb-843a-c04c0b587cd9.png)
This fixes the issue by disabling the fake glow sprite controllers on the two VRControllers in the game scene.  :)
