### PR TITLE
Added redecorator functionality and multiplayer registrations

### DIFF
--- a/SiraUtil/Objects/InternalRedecorator.cs
+++ b/SiraUtil/Objects/InternalRedecorator.cs
@@ -11,6 +11,8 @@ namespace SiraUtil.Objects
 {
     internal class InternalRedecorator
     {
+        private const string NewContextPrefabMethodName = "ByNewPrefabContext";
+
         private static readonly MethodInfo _getType = typeof(object).GetMethod(nameof(object.GetType));
         private static readonly MethodInfo _prefabInitializingField = SymbolExtensions.GetMethodInfo(() => PrefabInitializing(null!, null!, null!, null!));
         private static readonly MethodInfo _newPrefabMethod = typeof(FactoryFromBinderBase).GetMethod(nameof(FactoryFromBinderBase.FromComponentInNewPrefab));
@@ -95,7 +97,7 @@ namespace SiraUtil.Objects
 
             for (int i = 0; i < codes.Count - 1; i++)
             {
-                if (codes[i].opcode == OpCodes.Ldfld && (codes[i + 1].Calls(_newPrefabMethod) || (codes[i + 1].opcode == OpCodes.Callvirt && ((MethodInfo)codes[i + 1].operand).Name == "ByNewContextPrefab") || (codes.Count > i + 4 && codes[i + 4].Calls(_newPrefabMethod)))) // uhhh for teranary operators :PogOh:
+                if (codes[i].opcode == OpCodes.Ldfld && (codes[i + 1].Calls(_newPrefabMethod) || (codes[i + 1].opcode == OpCodes.Callvirt && ((MethodInfo)codes[i + 1].operand).Name == NewContextPrefabMethodName) || (codes.Count > i + 4 && codes[i + 4].Calls(_newPrefabMethod)))) // uhhh for teranary operators :PogOh:
                 {
                     if (containerOpcode is null && containerOperand is null)
                     {

--- a/SiraUtil/Objects/InternalRedecorator.cs
+++ b/SiraUtil/Objects/InternalRedecorator.cs
@@ -11,8 +11,7 @@ namespace SiraUtil.Objects
 {
     internal class InternalRedecorator
     {
-        private const string NewContextPrefabMethodName = "ByNewPrefabContext";
-
+        private const string NewContextPrefabMethodName = "ByNewContextPrefab";
         private static readonly MethodInfo _getType = typeof(object).GetMethod(nameof(object.GetType));
         private static readonly MethodInfo _prefabInitializingField = SymbolExtensions.GetMethodInfo(() => PrefabInitializing(null!, null!, null!, null!));
         private static readonly MethodInfo _newPrefabMethod = typeof(FactoryFromBinderBase).GetMethod(nameof(FactoryFromBinderBase.FromComponentInNewPrefab));

--- a/SiraUtil/Objects/Multiplayer/ConnectedPlayerDuelRegistration.cs
+++ b/SiraUtil/Objects/Multiplayer/ConnectedPlayerDuelRegistration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SiraUtil.Objects.Multiplayer
+{
+    /// <summary>
+    /// Registers a redecorator for the connected player in the duel.
+    /// </summary>
+    public sealed class ConnectedPlayerDuelRegistration : TemplateRedecoratorRegistration<MultiplayerConnectedPlayerFacade, MultiplayerPlayersManager>
+    {
+        /// <summary>
+        /// Creates a new redecorator registration.
+        /// </summary>
+        /// <param name="redecorateCall">This is called when the object is being redecorated.</param>
+        /// <param name="priority">The redecoration priority.</param>
+        /// <param name="chain">Whether to chain this redecoration with others. Every redecoration is now aggregated.
+        /// The chain will start if the highest priority object has chaining enabled and will stop once a registration
+        /// in the aggregate has chaining disabled.</param>
+        public ConnectedPlayerDuelRegistration(Func<MultiplayerConnectedPlayerFacade, MultiplayerConnectedPlayerFacade> redecorateCall, int priority = 0, bool chain = true) : base("_connectedPlayerDuelControllerPrefab", redecorateCall, priority, chain) { }
+    }
+}

--- a/SiraUtil/Objects/Multiplayer/ConnectedPlayerRegistration.cs
+++ b/SiraUtil/Objects/Multiplayer/ConnectedPlayerRegistration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SiraUtil.Objects.Multiplayer
+{
+    /// <summary>
+    /// Registers a redecorator for the connected player.
+    /// </summary>
+    public sealed class ConnectedPlayerRegistration : TemplateRedecoratorRegistration<MultiplayerConnectedPlayerFacade, MultiplayerPlayersManager>
+    {
+        /// <summary>
+        /// Creates a new redecorator registration.
+        /// </summary>
+        /// <param name="redecorateCall">This is called when the object is being redecorated.</param>
+        /// <param name="priority">The redecoration priority.</param>
+        /// <param name="chain">Whether to chain this redecoration with others. Every redecoration is now aggregated.
+        /// The chain will start if the highest priority object has chaining enabled and will stop once a registration
+        /// in the aggregate has chaining disabled.</param>
+        public ConnectedPlayerRegistration(Func<MultiplayerConnectedPlayerFacade, MultiplayerConnectedPlayerFacade> redecorateCall, int priority = 0, bool chain = true) : base("_connectedPlayerControllerPrefab", redecorateCall, priority, chain) { }
+    }
+}

--- a/SiraUtil/Objects/Multiplayer/LobbyAvatarPlaceRegistration.cs
+++ b/SiraUtil/Objects/Multiplayer/LobbyAvatarPlaceRegistration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SiraUtil.Objects.Multiplayer
+{
+    /// <summary>
+    /// Registers a redecorator for the lobby avatar place.
+    /// </summary>
+    public sealed class LobbyAvatarPlaceRegistration : TemplateRedecoratorRegistration<MultiplayerLobbyAvatarPlace, MultiplayerLobbyInstaller>
+    {
+        /// <summary>
+        /// Creates a new redecorator registration.
+        /// </summary>
+        /// <param name="redecorateCall">This is called when the object is being redecorated.</param>
+        /// <param name="priority">The redecoration priority.</param>
+        /// <param name="chain">Whether to chain this redecoration with others. Every redecoration is now aggregated.
+        /// The chain will start if the highest priority object has chaining enabled and will stop once a registration
+        /// in the aggregate has chaining disabled.</param>
+        public LobbyAvatarPlaceRegistration(Func<MultiplayerLobbyAvatarPlace, MultiplayerLobbyAvatarPlace> redecorateCall, int priority = 0, bool chain = true) : base("_multiplayerAvatarPlacePrefab", redecorateCall, priority, chain) { }
+    }
+}

--- a/SiraUtil/Objects/Multiplayer/LobbyAvatarRegistration.cs
+++ b/SiraUtil/Objects/Multiplayer/LobbyAvatarRegistration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SiraUtil.Objects.Multiplayer
+{
+    /// <summary>
+    /// Registers a redecorator for the lobby avatar controller.
+    /// </summary>
+    public sealed class LobbyAvatarRegistration : TemplateRedecoratorRegistration<MultiplayerLobbyAvatarController, MultiplayerLobbyInstaller>
+    {
+        /// <summary>
+        /// Creates a new redecorator registration.
+        /// </summary>
+        /// <param name="redecorateCall">This is called when the object is being redecorated.</param>
+        /// <param name="priority">The redecoration priority.</param>
+        /// <param name="chain">Whether to chain this redecoration with others. Every redecoration is now aggregated.
+        /// The chain will start if the highest priority object has chaining enabled and will stop once a registration
+        /// in the aggregate has chaining disabled.</param>
+        public LobbyAvatarRegistration(Func<MultiplayerLobbyAvatarController, MultiplayerLobbyAvatarController> redecorateCall, int priority = 0, bool chain = true) : base("_multiplayerLobbyAvatarControllerPrefab", redecorateCall, priority, chain) { }
+    }
+}

--- a/SiraUtil/Objects/Multiplayer/LocalActivePlayerDuelRegistration.cs
+++ b/SiraUtil/Objects/Multiplayer/LocalActivePlayerDuelRegistration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SiraUtil.Objects.Multiplayer
+{
+    /// <summary>
+    /// Registers a redecorator for the active local player in the duel environment.
+    /// </summary>
+    public sealed class LocalActivePlayerDuelRegistration : TemplateRedecoratorRegistration<MultiplayerLocalActivePlayerFacade, MultiplayerPlayersManager>
+    {
+        /// <summary>
+        /// Creates a new redecorator registration.
+        /// </summary>
+        /// <param name="redecorateCall">This is called when the object is being redecorated.</param>
+        /// <param name="priority">The redecoration priority.</param>
+        /// <param name="chain">Whether to chain this redecoration with others. Every redecoration is now aggregated.
+        /// The chain will start if the highest priority object has chaining enabled and will stop once a registration
+        /// in the aggregate has chaining disabled.</param>
+        public LocalActivePlayerDuelRegistration(Func<MultiplayerLocalActivePlayerFacade, MultiplayerLocalActivePlayerFacade> redecorateCall, int priority = 0, bool chain = true) : base("_activeLocalPlayerDuelControllerPrefab", redecorateCall, priority, chain) { }
+    }
+}

--- a/SiraUtil/Objects/Multiplayer/LocalActivePlayerRegistration.cs
+++ b/SiraUtil/Objects/Multiplayer/LocalActivePlayerRegistration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SiraUtil.Objects.Multiplayer
+{
+    /// <summary>
+    /// Registers a redecorator for the active local player.
+    /// </summary>
+    public sealed class LocalActivePlayerRegistration : TemplateRedecoratorRegistration<MultiplayerLocalActivePlayerFacade, MultiplayerPlayersManager>
+    {
+        /// <summary>
+        /// Creates a new redecorator registration.
+        /// </summary>
+        /// <param name="redecorateCall">This is called when the object is being redecorated.</param>
+        /// <param name="priority">The redecoration priority.</param>
+        /// <param name="chain">Whether to chain this redecoration with others. Every redecoration is now aggregated.
+        /// The chain will start if the highest priority object has chaining enabled and will stop once a registration
+        /// in the aggregate has chaining disabled.</param>
+        public LocalActivePlayerRegistration(Func<MultiplayerLocalActivePlayerFacade, MultiplayerLocalActivePlayerFacade> redecorateCall, int priority = 0, bool chain = true) : base("_activeLocalPlayerControllerPrefab", redecorateCall, priority, chain) { }
+    }
+}

--- a/SiraUtil/Objects/Multiplayer/LocalInactivePlayerRegistration.cs
+++ b/SiraUtil/Objects/Multiplayer/LocalInactivePlayerRegistration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SiraUtil.Objects.Multiplayer
+{
+    /// <summary>
+    /// Registers a redecorator for the inactive local player.
+    /// </summary>
+    public sealed class LocalInactivePlayerRegistration : TemplateRedecoratorRegistration<MultiplayerLocalInactivePlayerFacade, MultiplayerPlayersManager>
+    {
+        /// <summary>
+        /// Creates a new redecorator registration.
+        /// </summary>
+        /// <param name="redecorateCall">This is called when the object is being redecorated.</param>
+        /// <param name="priority">The redecoration priority.</param>
+        /// <param name="chain">Whether to chain this redecoration with others. Every redecoration is now aggregated.
+        /// The chain will start if the highest priority object has chaining enabled and will stop once a registration
+        /// in the aggregate has chaining disabled.</param>
+        public LocalInactivePlayerRegistration(Func<MultiplayerLocalInactivePlayerFacade, MultiplayerLocalInactivePlayerFacade> redecorateCall, int priority = 0, bool chain = true) : base("_inactiveLocalPlayerControllerPrefab", redecorateCall, priority, chain) { }
+    }
+}


### PR DESCRIPTION
Adds functionality in the redecorator for the following:
- `ByNewContextPrefab` bindings
- bindings outside of installers in classes with a `_container` field

Adds new registrations for multiplayer prefabs:
- LobbyAvatarPlaceRegistration
- LobbyAvatarRegistration
- LocalInactivePlayerRegistration
- LocalActivePlayerRegistration
- LocalActivePlayerDuelRegistration
- ConnectedPlayerRegistration
- ConnectedPlayerDuelRegistration