### PR TITLE
FPFC improvements and fixes for 1.31.1

### DIFF
--- a/SiraUtil/Installers/SiraSettingsInstaller.cs
+++ b/SiraUtil/Installers/SiraSettingsInstaller.cs
@@ -18,11 +18,17 @@ namespace SiraUtil.Installers
         {
             Container.BindInstance(_config.FPFCToggle).AsSingle();
             Container.BindInstance(_config.SongControl).AsSingle();
-            Container.BindInterfacesTo<FPFCSettingsController>().AsSingle();
 
             var args = Environment.GetCommandLineArgs();
             if (args.Any(a => a.Equals(FPFCToggle.EnableArgument, StringComparison.OrdinalIgnoreCase)) && !args.Any(a => a.Equals(FPFCToggle.DisableArgument, StringComparison.OrdinalIgnoreCase)))
+            {
+                Container.BindInterfacesTo<FPFCSettingsController>().AsSingle();
                 Container.BindInterfacesTo<FPFCAffinityDaemon>().AsSingle().NonLazy();
+            }
+            else
+            {
+                Container.Bind<IFPFCSettings>().To<NoFPFCSettings>().AsSingle();
+            }
         }
     }
 }

--- a/SiraUtil/SiraUtil.csproj
+++ b/SiraUtil/SiraUtil.csproj
@@ -97,6 +97,10 @@
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
             <Private>False</Private>
         </Reference>
+        <Reference Include="Unity.XR.Management">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.XR.Management.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
         <Reference Include="UnityEngine">
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
             <Private>False</Private>

--- a/SiraUtil/Tools/FPFC/FPFCAffinityDaemon.cs
+++ b/SiraUtil/Tools/FPFC/FPFCAffinityDaemon.cs
@@ -12,10 +12,6 @@ namespace SiraUtil.Tools.FPFC
         }
 
         [AffinityPrefix]
-        [AffinityPatch(typeof(FirstPersonFlyingController), nameof(FirstPersonFlyingController.Start))]
-        protected bool FPFCStart() => false;
-
-        [AffinityPrefix]
         [AffinityPatch(typeof(FirstPersonFlyingController), nameof(FirstPersonFlyingController.OnEnable))]
         protected bool FPFCOnEnable() => false;
 

--- a/SiraUtil/Tools/FPFC/FPFCFixDaemon.cs
+++ b/SiraUtil/Tools/FPFC/FPFCFixDaemon.cs
@@ -4,21 +4,18 @@ namespace SiraUtil.Tools.FPFC
 {
     internal class FPFCFixDaemon : IAffinity
     {
-        private readonly bool _isOculus;
         private readonly IFPFCSettings _fpfcSettings;
-        private readonly IVRPlatformHelper _vrPlatformHelper;
 
-        public FPFCFixDaemon(IFPFCSettings fpfcSettings, IVRPlatformHelper vrPlatformHelper)
+        public FPFCFixDaemon(IFPFCSettings fpfcSettings)
         {
             _fpfcSettings = fpfcSettings;
-            _vrPlatformHelper = vrPlatformHelper;
-            _isOculus = _vrPlatformHelper is OculusVRHelper;
         }
 
         [AffinityPatch(typeof(OculusVRHelper), nameof(OculusVRHelper.hasInputFocus), AffinityMethodType.Getter)]
+        [AffinityPatch(typeof(UnityXRHelper), nameof(UnityXRHelper.hasInputFocus), AffinityMethodType.Getter)]
         protected void ForceInputFocus(ref bool __result)
         {
-            if (_isOculus && _fpfcSettings.Enabled)
+            if (_fpfcSettings.Enabled)
                 __result = true;
         }
     }

--- a/SiraUtil/Tools/FPFC/FPFCFixDaemon.cs
+++ b/SiraUtil/Tools/FPFC/FPFCFixDaemon.cs
@@ -1,4 +1,5 @@
 ﻿using SiraUtil.Affinity;
+using UnityEngine;
 
 namespace SiraUtil.Tools.FPFC
 {
@@ -17,6 +18,13 @@ namespace SiraUtil.Tools.FPFC
         {
             if (_fpfcSettings.Enabled)
                 __result = true;
+        }
+
+        [AffinityPatch(typeof(UnityXRHelper), nameof(UnityXRHelper.GetThumbstickValue))]
+        protected void ForceInputFocus(ref Vector2 __result)
+        {
+            if (_fpfcSettings.Enabled)
+                __result = new Vector2(Input.GetAxis("Mouse ScrollWheel"), Input.GetAxis("Mouse ScrollWheel"));
         }
     }
 }

--- a/SiraUtil/Tools/FPFC/FPFCInstaller.cs
+++ b/SiraUtil/Tools/FPFC/FPFCInstaller.cs
@@ -8,12 +8,6 @@ namespace SiraUtil.Tools.FPFC
     {
         public override void InstallBindings()
         {
-            var args = Environment.GetCommandLineArgs();
-            if (!args.Any(a => a.Equals(FPFCToggle.EnableArgument, StringComparison.OrdinalIgnoreCase)) || args.Any(a => a.Equals(FPFCToggle.DisableArgument, StringComparison.OrdinalIgnoreCase)))
-            {
-                Container.Bind<IFPFCSettings>().To<NoFPFCSettings>().AsSingle();
-                return;
-            }
             Container.BindInterfacesTo<FPFCToggle>().AsSingle();
             Container.BindInterfacesTo<MenuFPFCListener>().AsSingle();
             Container.BindInterfacesTo<SmoothCameraListener>().AsSingle();

--- a/SiraUtil/Tools/FPFC/SimpleCameraController.cs
+++ b/SiraUtil/Tools/FPFC/SimpleCameraController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Specialized;
+using UnityEngine;
 
 namespace SiraUtil.Tools.FPFC
 {
@@ -19,7 +20,7 @@ namespace SiraUtil.Tools.FPFC
 
         protected void Awake()
         {
-            _targetCameraState.SetFromTransform(transform);
+            _targetCameraState.SetFromPose(new Vector3(0, 1.7f, 0), Quaternion.identity);
             _interpolatingCameraState.SetFromTransform(transform);
         }
 
@@ -87,6 +88,16 @@ namespace SiraUtil.Tools.FPFC
             public float x;
             public float y;
             public float z;
+
+            public void SetFromPose(Vector3 position, Quaternion rotation)
+            {
+                pitch = rotation.eulerAngles.x;
+                yaw = rotation.eulerAngles.y;
+                roll = rotation.eulerAngles.z;
+                x = position.x;
+                y = position.y;
+                z = position.z;
+            }
 
             public void SetFromTransform(Transform t)
             {

--- a/SiraUtil/manifest.json
+++ b/SiraUtil/manifest.json
@@ -6,7 +6,7 @@
   "version": "3.1.3-dev.3",
   "icon": "SiraUtil.Resources.logo.png",
   "description": "A powerful utility mod which expands the capabilities and provides more tools to Beat Saber modders.",
-  "gameVersion": "1.29.4",
+  "gameVersion": "1.31.1",
   "dependsOn": {
     "BSIPA": "^4.3.0"
   },


### PR DESCRIPTION
Yoink the patch on `FirstPersonFlyingController.Start` since it no longer exists & some various improvements related to changes due to the switch to OpenXR.

The XR loader init/deinit stuff is especially important for Oculus headsets since if they stop detecting user presence, the game just freezes/stops rendering. There might be a better way to address that specific issue but I thought we might as well fully disable the loader while in FPFC to avoid any other potential weird behaviour like that.