### PR TITLE
Fix null ref when debugging the game

### DIFF
--- a/SiraUtil/Sabers/Effects/SaberBurnMarkSparklesPatch.cs
+++ b/SiraUtil/Sabers/Effects/SaberBurnMarkSparklesPatch.cs
@@ -53,7 +53,7 @@ namespace SiraUtil.Sabers.Effects
                     {
                         new CodeInstruction(OpCodes.Ldarg_0),
                         new CodeInstruction(OpCodes.Ldfld, burnMarks), // this needs operand of _burnMarksPs or _sabers
-                        new CodeInstruction(OpCodes.Callvirt, _evaluateState)
+                        new CodeInstruction(OpCodes.Call, _evaluateState)
                     });
                     break;
                 }


### PR DESCRIPTION
I cannot tell exactly why it does fix it (~~Mono~~), but `Callvirt` is not appropriate there, since it calls a static method.

For reference, it solves that issue we already talked about often:

![image](https://github.com/Auros/SiraUtil/assets/793322/33d627a2-6c6c-4741-97c5-1bc0d54b8e86)
