### PR TITLE
Update for Beat Saber 1.35.0 & 1.36.0

### DIFF
--- a/SiraUtil/Sabers/Effects/SaberBurnMarkAreaLatch.cs
+++ b/SiraUtil/Sabers/Effects/SaberBurnMarkAreaLatch.cs
@@ -20,13 +20,9 @@ namespace SiraUtil.Sabers.Effects
         private static readonly FieldAccessor<SaberBurnMarkArea, Vector3[]>.Accessor PreviousMarks = FieldAccessor<SaberBurnMarkArea, Vector3[]>.GetAccessor("_prevBurnMarkPos");
         private static readonly FieldAccessor<SaberBurnMarkArea, bool[]>.Accessor PreviousMarksValid = FieldAccessor<SaberBurnMarkArea, bool[]>.GetAccessor("_prevBurnMarkPosValid");
         private static readonly FieldAccessor<SaberBurnMarkArea, LineRenderer>.Accessor LinePrefab = FieldAccessor<SaberBurnMarkArea, LineRenderer>.GetAccessor("_saberBurnMarkLinePrefab");
-        private static readonly FieldAccessor<SaberBurnMarkArea, int>.Accessor TextureWidth = FieldAccessor<SaberBurnMarkArea, int>.GetAccessor("_textureWidth");
-        private static readonly FieldAccessor<SaberBurnMarkArea, int>.Accessor TextureHeight = FieldAccessor<SaberBurnMarkArea, int>.GetAccessor("_textureHeight");
-        private int _lineFactoryIncrement;
 
         public SaberBurnMarkAreaLatch(SiraSaberFactory siraSaberFactory, SaberModelManager saberModelManager)
         {
-            _lineFactoryIncrement = 2;
             _siraSaberFactory = siraSaberFactory;
             _saberModelManager = saberModelManager;
             _siraSaberFactory.SaberCreated += SiraSaberFactory_SaberCreated;
@@ -90,14 +86,6 @@ namespace SiraUtil.Sabers.Effects
             return newLine;
         }
 
-        private RenderTexture CreateNewRenderTexture()
-        {
-            RenderTexture renderTexture = new(TextureWidth(ref _saberBurnMarkArea!), TextureHeight(ref _saberBurnMarkArea!), 0, RenderTextureFormat.ARGB32);
-            renderTexture.name = $"SiraUtil | SaberBurnMarkArea Texture {_lineFactoryIncrement++}";
-            renderTexture.hideFlags = HideFlags.DontSave;
-            return renderTexture;
-        }
-
         [AffinityPostfix]
         [AffinityPatch(typeof(SaberBurnMarkArea), nameof(SaberBurnMarkArea.Start))]
         internal void BurnAreaStarting(SaberBurnMarkArea __instance)
@@ -106,19 +94,6 @@ namespace SiraUtil.Sabers.Effects
             foreach (var siraSaber in _earlySabers)
                 AddSaber(siraSaber.Saber);
             _earlySabers.Clear();
-        }
-
-        [AffinityPostfix]
-        [AffinityPatch(typeof(SaberBurnMarkArea), nameof(SaberBurnMarkArea.LateUpdate))]
-        internal void AbsoluteCarouselRenderShift(ref RenderTexture[] ____renderTextures)
-        {
-            // Shift every render texture down one in the array
-            RenderTexture lastTexture = ____renderTextures[____renderTextures.Length - 1];
-            for (int i = ____renderTextures.Length - 1; i > 0; i--)
-            {
-                ____renderTextures[i] = ____renderTextures[i - 1];
-            }
-            ____renderTextures[0] = lastTexture;
         }
     }
 }

--- a/SiraUtil/SiraUtil.csproj
+++ b/SiraUtil/SiraUtil.csproj
@@ -54,6 +54,10 @@
         <Reference Include="0Harmony">
             <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
         </Reference>
+        <Reference Include="BeatSaber.Init">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.Init.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
         <Reference Include="BGLib.AppFlow">
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
             <Publicize>True</Publicize>

--- a/SiraUtil/Tools/FPFC/FPFCToggle.cs
+++ b/SiraUtil/Tools/FPFC/FPFCToggle.cs
@@ -3,13 +3,11 @@ using SiraUtil.Services;
 using SiraUtil.Zenject;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SpatialTracking;
-using UnityEngine.XR.Management;
 using VRUIControls;
 using Zenject;
 
@@ -135,8 +133,6 @@ namespace SiraUtil.Tools.FPFC
 
             foreach (var listener in _fpfcListeners)
                 listener.Enabled();
-
-            DeinitializeXRLoader();
         }
 
         private void DisableFPFC()
@@ -179,8 +175,6 @@ namespace SiraUtil.Tools.FPFC
 
             foreach (var listener in _fpfcListeners)
                 listener.Disabled();
-
-            InitializeXRLoader();
         }
 
         public void Dispose()
@@ -196,37 +190,6 @@ namespace SiraUtil.Tools.FPFC
                 Cursor.lockState = CursorLockMode.Locked;
                 Cursor.visible = false;
             }
-        }
-
-        // we unfortunately need to fully deinitialize/initialize the XR loader since OpenXR doesn't simply stop/start properly
-        private void InitializeXRLoader()
-        {
-            XRManagerSettings manager = XRGeneralSettings.Instance.Manager;
-
-            if (manager.activeLoader != null || !manager.activeLoaders.Any(l => l != null))
-                return;
-
-            _siraLog.Notice("Enabling XR Loader");
-            manager.InitializeLoaderSync();
-
-            if (!manager.isInitializationComplete)
-            {
-                _siraLog.Error("Failed to initialize XR loader");
-                return;
-            }
-
-            manager.StartSubsystems();
-        }
-
-        private void DeinitializeXRLoader()
-        {
-            XRManagerSettings manager = XRGeneralSettings.Instance.Manager;
-
-            if (manager.activeLoader == null)
-                return;
-
-            _siraLog.Notice("Disabling XR Loader");
-            manager.DeinitializeLoader();
         }
     }
 }

--- a/SiraUtil/Tools/FPFC/FPFCToggle.cs
+++ b/SiraUtil/Tools/FPFC/FPFCToggle.cs
@@ -186,8 +186,6 @@ namespace SiraUtil.Tools.FPFC
         public void Dispose()
         {
             _fpfcSettings.Changed -= FPFCSettings_Changed;
-
-            InitializeXRLoader();
         }
 
         public void Tick()

--- a/SiraUtil/Zenject/Harmony/LateBoundInjector.cs
+++ b/SiraUtil/Zenject/Harmony/LateBoundInjector.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using IPA.Utilities;
 using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -13,7 +12,7 @@ namespace SiraUtil.Zenject.Harmony
         private static SiraPCScenesTransitionSetupDataSO _restartTransitionData = null!;
 
         [HarmonyPrefix]
-        public static bool Prefix(GameScenesManager __instance, ScenesTransitionSetupDataSO scenesTransitionSetupData)
+        public static bool Prefix(GameScenesManager __instance)
         {
             if (!ZenjectManager.InitialSceneConstructionRegistered)
             {
@@ -23,8 +22,8 @@ namespace SiraUtil.Zenject.Harmony
                 }
                 __instance.ClearAndOpenScenes(_restartTransitionData, finishCallback: (_) =>
                 {
-                    PCAppInit pcAppInit = SceneManager.GetSceneByName(__instance.GetCurrentlyLoadedSceneNames()[0]).GetRootGameObjects()[0].GetComponent<PCAppInit>();
-                    pcAppInit.InvokeMethod<object, PCAppInit>("TransitionToNextScene");
+                    PCAppInit pcAppInit = SceneManager.GetSceneByName(_initialSceneName).GetRootGameObjects()[0].GetComponent<PCAppInit>();
+                    pcAppInit.TransitionToNextScene();
                 });
                 return false;
             }
@@ -36,7 +35,7 @@ namespace SiraUtil.Zenject.Harmony
             protected override void OnEnable()
             {
                 var si = CreateInstance<SceneInfo>();
-                si.SetField("_sceneName", _initialSceneName);
+                si._sceneName = _initialSceneName;
                 Init(new SceneInfo[] { si }, Array.Empty<SceneSetupData>());
                 base.OnEnable();
             }

--- a/SiraUtil/manifest.json
+++ b/SiraUtil/manifest.json
@@ -3,7 +3,7 @@
   "id": "SiraUtil",
   "name": "SiraUtil",
   "author": "Auros",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "icon": "SiraUtil.Resources.logo.png",
   "description": "A powerful utility mod which provides more tools to Beat Saber modders.",
   "gameVersion": "1.35.0",

--- a/SiraUtil/manifest.json
+++ b/SiraUtil/manifest.json
@@ -3,10 +3,10 @@
   "id": "SiraUtil",
   "name": "SiraUtil",
   "author": "Auros",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "icon": "SiraUtil.Resources.logo.png",
   "description": "A powerful utility mod which provides more tools to Beat Saber modders.",
-  "gameVersion": "1.34.5",
+  "gameVersion": "1.35.0",
   "dependsOn": {
     "BSIPA": "^4.3.0"
   },


### PR DESCRIPTION
Fixes the breaking change that occurred with 1.35.0 (PCAppInit got moved) and the transpiler that broke with 1.36.0. The modified transpiler still works with 1.35.0 so I kept that as the game version in the manifest.