### PR TITLE
Fix StandardSongControl.IsPaused

### DIFF
--- a/SiraUtil/Tools/SongControl/StandardSongControl.cs
+++ b/SiraUtil/Tools/SongControl/StandardSongControl.cs
@@ -11,7 +11,7 @@ namespace SiraUtil.Tools.SongControl
             _pauseController = pauseController;
         }
 
-        public bool IsPaused => _pauseController.GetField<bool, PauseController>("_paused");
+        public bool IsPaused => _pauseController._paused == PauseController.PauseState.Paused;
 
         public void Continue()
         {


### PR DESCRIPTION
On 1.40.0 (maybe before as well, did not test), using the F2 pause feature will cause an uncaught exception.
Given the exception is thrown in the `StandardSongControl` implementation of `ISongControl`, any mods that access `ISongControl.IsPaused` in singleplayer will also be affected.
This pr fixes it.

```
[CRITICAL @ 23:58:11 | UnityEngine] ArgumentException: Field '_paused' not of type System.Boolean
[CRITICAL @ 23:58:11 | UnityEngine] IPA.Utilities.FieldAccessor`2[T,U].MakeAccessor (System.String fieldName) (at D:/a/BeatSaber-IPA-Reloaded/BeatSaber-IPA-Reloaded/IPA.Loader/Utilities/Accessor.cs:51)
[CRITICAL @ 23:58:11 | UnityEngine] IPA.Utilities.Async.SingleCreationValueCache`2[TKey,TValue].GetOrAdd (TKey key, System.Func`2[T,TResult] creator) (at D:/a/BeatSaber-IPA-Reloaded/BeatSaber-IPA-Reloaded/IPA.Loader/Utilities/Async/SingleCreationValueCache.cs:156)
[CRITICAL @ 23:58:11 | UnityEngine] IPA.Utilities.FieldAccessor`2[T,U].GetAccessor (System.String name) (at D:/a/BeatSaber-IPA-Reloaded/BeatSaber-IPA-Reloaded/IPA.Loader/Utilities/Accessor.cs:64)
[CRITICAL @ 23:58:11 | UnityEngine] IPA.Utilities.FieldAccessor`2[T,U].Access (T& obj, System.String name) (at D:/a/BeatSaber-IPA-Reloaded/BeatSaber-IPA-Reloaded/IPA.Loader/Utilities/Accessor.cs:74)
[CRITICAL @ 23:58:11 | UnityEngine] IPA.Utilities.FieldAccessor`2[T,U].Get (T& obj, System.String name) (at D:/a/BeatSaber-IPA-Reloaded/BeatSaber-IPA-Reloaded/IPA.Loader/Utilities/Accessor.cs:89)
[CRITICAL @ 23:58:11 | UnityEngine] IPA.Utilities.ReflectionUtil.GetField[U,T] (T obj, System.String fieldName) (at D:/a/BeatSaber-IPA-Reloaded/BeatSaber-IPA-Reloaded/IPA.Loader/Utilities/ReflectionUtil.cs:40)
[CRITICAL @ 23:58:11 | UnityEngine] SiraUtil.Tools.SongControl.StandardSongControl.get_IsPaused () (at /_/SiraUtil/Tools/SongControl/StandardSongControl.cs:14)
[CRITICAL @ 23:58:11 | UnityEngine] SiraUtil.Tools.SongControl.SongControlManager.Tick () (at /_/SiraUtil/Tools/SongControl/SongControlManager.cs:25)
[CRITICAL @ 23:58:11 | UnityEngine] Zenject.TickablesTaskUpdater.UpdateItem (Zenject.ITickable task) (at <216eee2c32db494ab39896d41fcc4e32>:0)
[CRITICAL @ 23:58:11 | UnityEngine] Zenject.TaskUpdater`1[TTask].UpdateRange (System.Int32 minPriority, System.Int32 maxPriority) (at <216eee2c32db494ab39896d41fcc4e32>:0)
[CRITICAL @ 23:58:11 | UnityEngine] Zenject.TaskUpdater`1[TTask].UpdateAll () (at <216eee2c32db494ab39896d41fcc4e32>:0)
[CRITICAL @ 23:58:11 | UnityEngine] Zenject.TickableManager.Update () (at <216eee2c32db494ab39896d41fcc4e32>:0)
[CRITICAL @ 23:58:11 | UnityEngine] Zenject.MonoKernel.Update () (at <216eee2c32db494ab39896d41fcc4e32>:0)
```

