### PR TITLE
Allow resolving IPA Logger when using SiraLog

### DIFF
--- a/SiraUtil.Suite/Tests/SomeManager.cs
+++ b/SiraUtil.Suite/Tests/SomeManager.cs
@@ -1,4 +1,5 @@
-﻿using SiraUtil.Attributes;
+﻿using IPA.Logging;
+using SiraUtil.Attributes;
 using SiraUtil.Logging;
 using SiraUtil.Zenject;
 using Zenject;
@@ -11,6 +12,13 @@ namespace SiraUtil.Suite.Tests
         [Inject]
         private readonly SiraLog _siraLog = null!;
 
+        [Inject]
+        public void Init(Logger ipaLogger)
+        {
+            _siraLog.Debug("SomeManager inject method");
+            ipaLogger.Debug("SomeManager inject method but logged with IPA logger");
+        }
+        
         public void Initialize()
         {
             _siraLog.Info($"Created {nameof(SomeManager)}");

--- a/SiraUtil/Installers/SiraInitializationInstaller.cs
+++ b/SiraUtil/Installers/SiraInitializationInstaller.cs
@@ -1,4 +1,5 @@
-﻿using SiraUtil.Logging;
+﻿using IPA.Logging;
+using SiraUtil.Logging;
 using SiraUtil.Services.Events;
 using SiraUtil.Submissions;
 using SiraUtil.Tools.FPFC;
@@ -44,6 +45,7 @@ namespace SiraUtil.Installers
                 if (zenjector.Logger is not null)
                     _siraLogManager.AddLogger(zenjector.Metadata.Assembly, zenjector.Logger);
             Container.Bind<SiraLog>().AsTransient().OnInstantiated<SiraLog>(SiraLogCreated);
+            Container.Bind<Logger>().FromMethod(CreateIPAChildLogger).AsTransient();
 
             // Takes every active zenjector and adds them to the http service.
             _httpServiceManager.Clear();
@@ -69,6 +71,12 @@ namespace SiraUtil.Installers
             // When a SiraLog is instantiated, add its backing logger and its default value for debug mode.
             SiraLogManager.LoggerContext loggerContext = _siraLogManager.LoggerFromAssembly(ctx.ObjectType.Assembly);
             siraLog.Setup(loggerContext.logger, ctx.ObjectType.Name, loggerContext.debugMode);
+        }
+
+        private Logger CreateIPAChildLogger(InjectContext ctx)
+        {
+            SiraLogManager.LoggerContext loggerContext = _siraLogManager.LoggerFromAssembly(ctx.ObjectType.Assembly);
+            return loggerContext.logger.GetChildLogger(ctx.ObjectType.Name);
         }
 
         private void HttpServiceCreated(InjectContext ctx, IHttpService httpService)


### PR DESCRIPTION
IPA's logger allows showing call source and file line numbers in a debug log message by using the stacktrace. However, when using SiraLog, because SiraLog wraps the IPA logger, the call source will always be SiraUtil's SiraLog class. 

This PR allows any usage site to resolve the IPA logger directly without wrapping, thus making the call site info useful again. 

Example:
```
[INFO @ 00:30:28 | HRCounter/SettingMenuController] Loading custom icons
[DEBUG @ 00:30:28 | HRCounter/IconManager] {/_/SiraUtil/Logging/SiraLog.cs:96} Loading all icons
[DEBUG @ 00:30:29 | HRCounter/IconManager] {/_/SiraUtil/Logging/SiraLog.cs:96} Loaded 7 icons
[DEBUG @ 00:30:29 | HRCounter/SettingMenuController] {D:\VR\Beat Saber\creation\HRCounter\HRCounter\UI\SettingMenuController.cs:188} Loaded 8 custom icon options
```
In the above example, `SettingMenuController` is using the IPA logger while IconManager is using `SiraLog`