### PR TITLE
Un-hardcode timeout value for UWRHttpService.SendRawAsync

### DIFF
--- a/SiraUtil/Web/IHttpService.cs
+++ b/SiraUtil/Web/IHttpService.cs
@@ -29,6 +29,11 @@ namespace SiraUtil.Web
         /// The user agent for your requests. By default, it will be set to: '[Mod Name]/[Mod Version] ([IHttpService Provider Name]; [SiraUtil Version]; Beat Saber; [Beat Saber Version])  
         /// </summary>
         string? UserAgent { get; set; }
+        
+        /// <summary>
+        /// The default delay (in seconds) until a timeout is reached. Defaults to 60.
+        /// </summary>
+        int? Timeout { get; set; }
 
         /// <summary>
         /// The default headers for your requests. Token and UserAgent are synchronized with this.
@@ -41,8 +46,9 @@ namespace SiraUtil.Web
         /// <param name="url">The URL to send the request to.</param>
         /// <param name="progress"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="timeout">The delay (in seconds) until a timeout is reached.</param>
         /// <returns>The response.</returns>
-        Task<IHttpResponse> GetAsync(string url, IProgress<float>? progress = null, CancellationToken? cancellationToken = null);
+        Task<IHttpResponse> GetAsync(string url, IProgress<float>? progress = null, CancellationToken? cancellationToken = null, int? timeout = null);
 
         /// <summary>
         /// Creates a HTTP POST request.
@@ -50,8 +56,9 @@ namespace SiraUtil.Web
         /// <param name="url">The URL to send the request to.</param>
         /// <param name="body">The content to include as a UTF-8 JSON body. The object put in here will be automatically serialized.</param>
         /// <param name="cancellationToken"></param>
+        /// <param name="timeout">The delay (in seconds) until a timeout is reached.</param>
         /// <returns>The response.</returns>
-        Task<IHttpResponse> PostAsync(string url, object? body = null, CancellationToken? cancellationToken = null);
+        Task<IHttpResponse> PostAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null);
 
         /// <summary>
         /// Creates a HTTP PUT request.
@@ -59,8 +66,9 @@ namespace SiraUtil.Web
         /// <param name="url">The URL to send the request to.</param>
         /// <param name="body">The content to include as a UTF-8 JSON body. The object put in here will be automatically serialized.</param>
         /// <param name="cancellationToken"></param>
+        /// <param name="timeout">The delay (in seconds) until a timeout is reached.</param>
         /// <returns>The response.</returns>
-        Task<IHttpResponse> PutAsync(string url, object? body = null, CancellationToken? cancellationToken = null);
+        Task<IHttpResponse> PutAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null);
 
         /// <summary>
         /// Creates a HTTP PATCH request.
@@ -68,16 +76,18 @@ namespace SiraUtil.Web
         /// <param name="url">The URL to send the request to.</param>
         /// <param name="body">The content to include as a UTF-8 JSON body. The object put in here will be automatically serialized.</param>
         /// <param name="cancellationToken"></param>
+        /// <param name="timeout">The delay (in seconds) until a timeout is reached.</param>
         /// <returns>The response.</returns>
-        Task<IHttpResponse> PatchAsync(string url, object? body = null, CancellationToken? cancellationToken = null);
+        Task<IHttpResponse> PatchAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null);
 
         /// <summary>
         /// Creates a HTTP DELETE request.
         /// </summary>
         /// <param name="url">The URL to send the request to.</param>
         /// <param name="cancellationToken"></param>
+        /// <param name="timeout">The delay (in seconds) until a timeout is reached.</param>
         /// <returns>The response.</returns>
-        Task<IHttpResponse> DeleteAsync(string url, CancellationToken? cancellationToken = null);
+        Task<IHttpResponse> DeleteAsync(string url, CancellationToken? cancellationToken = null, int? timeout = null);
 
         /// <summary>
         /// Sends a message asynchronously.
@@ -88,7 +98,8 @@ namespace SiraUtil.Web
         /// <param name="withHeaders">Additional headers on top of the default headers. This will be combined with the default headers associated with this <see cref="IHttpService"/></param>
         /// <param name="downloadProgress">The download progress of the request.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the token with.</param>
+        /// <param name="timeout">The delay (in seconds) until a timeout is reached.</param>
         /// <returns></returns>
-        Task<IHttpResponse> SendAsync(HTTPMethod method, string url, string? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null);
+        Task<IHttpResponse> SendAsync(HTTPMethod method, string url, string? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null, int? timeout = null);
     }
 }

--- a/SiraUtil/Web/Implementations/UWRHttpService.cs
+++ b/SiraUtil/Web/Implementations/UWRHttpService.cs
@@ -44,42 +44,44 @@ namespace SiraUtil.Web.Implementations
             }
         }
 
-        public Task<IHttpResponse> GetAsync(string url, IProgress<float>? progress = null, CancellationToken? cancellationToken = null)
+        public int? Timeout { get; set; } = 60;
+
+        public Task<IHttpResponse> GetAsync(string url, IProgress<float>? progress = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return SendAsync(HTTPMethod.GET, url, null, null, progress, cancellationToken);
+            return SendAsync(HTTPMethod.GET, url, null, null, progress, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> PostAsync(string url, object? body = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> PostAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return SendAsync(HTTPMethod.POST, url, JsonConvert.SerializeObject(body), null, null, cancellationToken);
+            return SendAsync(HTTPMethod.POST, url, JsonConvert.SerializeObject(body), null, null, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> PutAsync(string url, object? body = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> PutAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return SendAsync(HTTPMethod.PUT, url, JsonConvert.SerializeObject(body), null, null, cancellationToken);
+            return SendAsync(HTTPMethod.PUT, url, JsonConvert.SerializeObject(body), null, null, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> PatchAsync(string url, object? body = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> PatchAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return SendAsync(HTTPMethod.PATCH, url, JsonConvert.SerializeObject(body), null, null, cancellationToken);
+            return SendAsync(HTTPMethod.PATCH, url, JsonConvert.SerializeObject(body), null, null, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> DeleteAsync(string url, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> DeleteAsync(string url, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return SendAsync(HTTPMethod.DELETE, url, null, null, null, cancellationToken);
+            return SendAsync(HTTPMethod.DELETE, url, null, null, null, cancellationToken, timeout);
         }
 
-        public async Task<IHttpResponse> SendAsync(HTTPMethod method, string url, string? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null)
+        public async Task<IHttpResponse> SendAsync(HTTPMethod method, string url, string? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
             if (body is not null)
             {
                 withHeaders ??= new Dictionary<string, string>();
                 withHeaders.Add("Content-Type", "application/json");
             }
-            return await SendRawAsync(method, url, body is not null ? Encoding.UTF8.GetBytes(body) : null, withHeaders, downloadProgress, cancellationToken);
+            return await SendRawAsync(method, url, body is not null ? Encoding.UTF8.GetBytes(body) : null, withHeaders, downloadProgress, cancellationToken, timeout);
         }
 
-        public async Task<IHttpResponse> SendRawAsync(HTTPMethod method, string url, byte[]? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null)
+        public async Task<IHttpResponse> SendRawAsync(HTTPMethod method, string url, byte[]? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
             // I HATE UNITY I HATE UNITY I HATE UNITY
             var response = await await UnityMainThreadTaskScheduler.Factory.StartNew(async () =>
@@ -94,7 +96,7 @@ namespace SiraUtil.Web.Implementations
                     method = HTTPMethod.PUT;
 
                 using UnityWebRequest request = new(newURL, method.ToString(), dHandler, body == null ? null : new UploadHandlerRaw(body));
-                request.timeout = 60;
+                request.timeout = timeout ?? Timeout ?? 60;
 
                 foreach (var header in Headers)
                     request.SetRequestHeader(header.Key, header.Value);

--- a/SiraUtil/Web/Zenject/ContainerizedHttpService.cs
+++ b/SiraUtil/Web/Zenject/ContainerizedHttpService.cs
@@ -26,6 +26,12 @@ namespace SiraUtil.Web.Zenject
             set => _childService.UserAgent = value;
         }
 
+        public int? Timeout
+        {
+            get => _childService.Timeout;
+            set => _childService.Timeout = value;
+        }
+
         public IDictionary<string, string> Headers => _childService.Headers;
 
         public void Setup(IHttpService childService)
@@ -33,34 +39,34 @@ namespace SiraUtil.Web.Zenject
             _childService = childService;
         }
 
-        public Task<IHttpResponse> DeleteAsync(string url, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> DeleteAsync(string url, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return _childService.DeleteAsync(url, cancellationToken);
+            return _childService.DeleteAsync(url, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> GetAsync(string url, IProgress<float>? progress = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> GetAsync(string url, IProgress<float>? progress = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return _childService.GetAsync(url, progress, cancellationToken);
+            return _childService.GetAsync(url, progress, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> PatchAsync(string url, object? body = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> PatchAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return _childService.PatchAsync(url, body, cancellationToken);
+            return _childService.PatchAsync(url, body, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> PostAsync(string url, object? body = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> PostAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return _childService.PostAsync(url, body, cancellationToken);
+            return _childService.PostAsync(url, body, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> PutAsync(string url, object? body = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> PutAsync(string url, object? body = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return _childService.PutAsync(url, body, cancellationToken);
+            return _childService.PutAsync(url, body, cancellationToken, timeout);
         }
 
-        public Task<IHttpResponse> SendAsync(HTTPMethod method, string url, string? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null)
+        public Task<IHttpResponse> SendAsync(HTTPMethod method, string url, string? body = null, IDictionary<string, string>? withHeaders = null, IProgress<float>? downloadProgress = null, CancellationToken? cancellationToken = null, int? timeout = null)
         {
-            return _childService.SendAsync(method, url, body, withHeaders, downloadProgress, cancellationToken);
+            return _childService.SendAsync(method, url, body, withHeaders, downloadProgress, cancellationToken, timeout);
         }
     }
 }


### PR DESCRIPTION
Previous value was hardcoded to 60 seconds, which causes issues on slow connections as it includes data transfer time as well.

Left default at the old hardcoded 60 second value, but can be changed in the property value (which applies to the whole child service) or as a function argument.